### PR TITLE
fix goscout containerization

### DIFF
--- a/goscout/Dockerfile
+++ b/goscout/Dockerfile
@@ -3,9 +3,9 @@ ARG SQL_SRV
 WORKDIR /goscout
 COPY ./ ./
 RUN go get -d -v ./...
-RUN go build -v -ldflags "-X main.server=$SQL_SRV -linkmode external -extldflags -static" -o GoScout -a main.go
+RUN go build -v -ldflags "-linkmode external -extldflags -static" -o GoScout -a main.go
 
 FROM scratch
 COPY --from=builder /goscout/GoScout .
-EXPOSE 80 443 9005
+EXPOSE 15338
 ENTRYPOINT ["/GoScout"]

--- a/goscout/main.go
+++ b/goscout/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/gorilla/mux"
@@ -14,6 +15,7 @@ import (
 var server string
 
 func main() {
+	server = os.Getenv("GOSCOUT_SQL_USER") + ":" + os.Getenv("GOSCOUT_SQL_PASSWD") + "@tcp(" + os.Getenv("GOSCOUT_SQL_HOST") + ")/strangescout"
 	startAPI()
 }
 
@@ -83,9 +85,12 @@ func writeMatch(w http.ResponseWriter, r *http.Request) {
 
 	var data matchScoutData
 	_ = json.NewDecoder(r.Body).Decode(&data)
-	data.Event = "2018turing"
-	fmt.Printf("%+v\n", data)
 
+	// now hardcoding is optional and set by environment variable
+        if os.LookupEnv("GOSCOUT_EVENT_HARDCODE") {
+		data.Event = os.Getenv("GOSCOUT_EVENT_HARDCODE");
+        }
+	fmt.Printf("%+v\n", data)
 	// initialize SQL and test connection
 	rds, err := sql.Open("mysql", server)
 	if err != nil {
@@ -116,12 +121,14 @@ func writePit(w http.ResponseWriter, r *http.Request) {
 
 	var data pitScoutData
 	_ = json.NewDecoder(r.Body).Decode(&data)
-	data.Event = "2018turning"
+	// now hardcoding is optional and set by environment variable
+        if os.LookupEnv("GOSCOUT_EVENT_HARDCODE") {
+		data.Event = os.Getenv("GOSCOUT_EVENT_HARDCODE");
+        }
 	fmt.Printf("%+v\n", data)
 
 	// initialize SQL and test connection
-	rds, err := sql.Open("mysql",
-		"awsuser:$tran6e$c%ut@tcp(strangescout.cd1niyuzf8s7.us-east-1.rds.amazonaws.com)/strangescout")
+	rds, err := sql.Open("mysql", server)
 	if err != nil {
 		log.Fatal(err)
 	} else {

--- a/jscout/Caddyfile
+++ b/jscout/Caddyfile
@@ -28,7 +28,7 @@
 # API DOMAIN
 api.{$JSCOUT_DOMAIN} {
 		
-	proxy / localhost:9005
+	proxy / {$GOSCOUT_HOST}:15338
 	# A GoScout API server must be exposed to this container on port 9005.
 
 	tls {$JSCOUT_LETS_ENCRYPT_EMAIL}


### PR DESCRIPTION
- Read environment variables at runtime with `os.Getenv`
- Properly read SQL params from standard, implemetation agnostic variables
- Use 'os.LookupEnv' to check for event override. Remove `2018turing` hardcode

Testing now...