### PR TITLE
fix regression in pit form

### DIFF
--- a/jscout/src/app/pit-form/pit-form.component.ts
+++ b/jscout/src/app/pit-form/pit-form.component.ts
@@ -50,7 +50,7 @@ export class PitFormComponent implements OnInit {
       //Call a function when the state changes.
       if (xhr.readyState == XMLHttpRequest.DONE && (xhr.status <= 299 || xhr.status == 409)) {
         // Clear form. Data is either recorded or duplicate.
-        (<HTMLFormElement>document.getElementById("matchForm")).reset();
+        (<HTMLFormElement>document.getElementById("pitForm")).reset();
         alert(`Message from server: ${xhr.status} ${xhr.statusText} -- ${xhr.responseText}`);
       } else if (xhr.readyState == XMLHttpRequest.DONE && xhr.status >= 300) {
         // Don't clear form. 


### PR DESCRIPTION
when copying and pasting code for #16 the descriptor `"matchForm"` was never changed back to `"pitForm"` causing there to be no user feedback on a code `<=299` or `409` because the clear instruction failed
rip

somehow this also fixed #18 but only with regard to the pit form