### PR TITLE
New splash

### DIFF
--- a/jscout/src/app/app.component.html
+++ b/jscout/src/app/app.component.html
@@ -27,6 +27,18 @@
 
 <div *ngIf="visiblePage == 'splash'" class="container-fluid form-container">
 	<!-- Home page content goes here -->
+	<div class="narrow-column">
+		<span><legend>Team:</legend></span>
+		<span>
+			<input type="number" class="form-control" [(ngModel)]="team">
+		</span>
+	</div>
+	<div class="narrow-column">
+			<span><legend>Run:</legend></span>
+			<span>
+				<input type="number" class="form-control" [(ngModel)]="run">
+			</span>
+	</div>
 	<div class="center-content">
 		<button class="btn btn-default btn-primary item" (click)="visiblePage='run'">Scout!</button>
 	</div>
@@ -34,5 +46,5 @@
 
 <!-- Run scouting form -->
 <div *ngIf="visiblePage == 'run'" class="container-fluid form-container">
-  <app-run-form [setupQuestions]="setupQuestions" [autoQuestions]="autoQuestions" [teleopQuestions]="teleopQuestions" [endgameQuestions]="endgameQuestions"></app-run-form>
+  <app-run-form [team]="team" [run]="run" [setupQuestions]="setupQuestions" [autoQuestions]="autoQuestions" [teleopQuestions]="teleopQuestions" [endgameQuestions]="endgameQuestions"></app-run-form>
 </div>

--- a/jscout/src/app/app.component.html
+++ b/jscout/src/app/app.component.html
@@ -30,17 +30,17 @@
 	<div class="narrow-column">
 		<span><legend>Team:</legend></span>
 		<span>
-			<input type="number" class="form-control" [(ngModel)]="team">
+			<input type="number" class="form-control" #teamInput="ngModel" [(ngModel)]="team" required>
 		</span>
 	</div>
 	<div class="narrow-column">
 			<span><legend>Run:</legend></span>
 			<span>
-				<input type="number" class="form-control" [(ngModel)]="run">
+				<input type="number" class="form-control" #runInput="ngModel" [(ngModel)]="run" required>
 			</span>
 	</div>
 	<div class="center-content">
-		<button class="btn btn-default btn-primary item" (click)="visiblePage='run'">Scout!</button>
+		<button class="btn btn-default btn-primary item" [disabled]="!runInput.valid || !teamInput.valid" (click)="visiblePage='run'">Scout!</button>
 	</div>
 </div>
 

--- a/jscout/src/app/app.component.ts
+++ b/jscout/src/app/app.component.ts
@@ -21,6 +21,9 @@ export class AppComponent {
 
   visiblePage = 'splash';
 
+  team: number;
+  run: number;
+
   constructor(qservice: QuestionService, updates: SwUpdate) {
     this.setupQuestions = qservice.getSetupQuestions();
     this.autoQuestions = qservice.getAutoQuestions();

--- a/jscout/src/app/app.component.ts
+++ b/jscout/src/app/app.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { PlatformLocation } from '@angular/common'
 import { SwUpdate } from '@angular/service-worker';
 import { interval } from 'rxjs';
 import { QuestionService } from './question.service';
@@ -24,7 +25,13 @@ export class AppComponent {
   team: number;
   run: number;
 
-  constructor(qservice: QuestionService, updates: SwUpdate) {
+  constructor(location: PlatformLocation, qservice: QuestionService, updates: SwUpdate) {
+
+    location.onPopState(() => {
+      console.log('pressed back!');
+      this.visiblePage = 'splash';
+    }); history.pushState({}, '');
+
     this.setupQuestions = qservice.getSetupQuestions();
     this.autoQuestions = qservice.getAutoQuestions();
     this.teleopQuestions = qservice.getTeleopQuestions();
@@ -43,5 +50,4 @@ export class AppComponent {
     });
     interval(30000).subscribe(() => updates.checkForUpdate());
   }
-
 }

--- a/jscout/src/app/app.module.ts
+++ b/jscout/src/app/app.module.ts
@@ -1,5 +1,5 @@
 import { BrowserModule }                from '@angular/platform-browser';
-import { ReactiveFormsModule }          from '@angular/forms';
+import { FormsModule, ReactiveFormsModule }          from '@angular/forms';
 import { NgModule }                     from '@angular/core';
 
 import { AppComponent }                 from './app.component';
@@ -17,7 +17,7 @@ import { environment } from '../environments/environment';
 
 
 @NgModule({
-  imports: [ BrowserModule, ReactiveFormsModule, BrowserAnimationsModule, MatToolbarModule, MatMenuModule, MatButtonModule, MatIconModule, ServiceWorkerModule.register('ngsw-worker.js', { enabled: environment.production })],
+  imports: [ BrowserModule, FormsModule, ReactiveFormsModule, BrowserAnimationsModule, MatToolbarModule, MatMenuModule, MatButtonModule, MatIconModule, ServiceWorkerModule.register('ngsw-worker.js', { enabled: environment.production })],
   declarations: [ AppComponent, RunFormComponent, FormQuestionComponent ],
   bootstrap: [ AppComponent ]
 })

--- a/jscout/src/app/question.service.ts
+++ b/jscout/src/app/question.service.ts
@@ -14,7 +14,7 @@ export class QuestionService {
   // TODO: make asynchronous
   getSetupQuestions() {
     let questions: QuestionBase<any>[] = [
-
+/*
       new NumberQuestion({
         key: 'TeamNumber',
         label: 'Team Number',
@@ -30,7 +30,7 @@ export class QuestionService {
         order: 2,
         min: 1
       }),
-
+*/
       new DropdownQuestion({
         key: 'StartPosition',
         label: 'Robot Starting Position',

--- a/jscout/src/app/run-form/run-form.component.html
+++ b/jscout/src/app/run-form/run-form.component.html
@@ -3,6 +3,10 @@
 
     <fieldset>
       <legend>Setup</legend>
+
+      <div><b>Team:</b> {{ numbers.get('TeamNumber').value }}</div>
+      <div><b>Run:</b> {{ numbers.get('MatchNumber').value }}</div>
+
       <div *ngFor="let question of setupQuestions" class="form-group">
         <app-question [question]="question" [form]="setupForm"></app-question>
       </div>
@@ -38,3 +42,5 @@
     </div>
   </form>
 </div>
+
+{{ payload }}

--- a/jscout/src/app/run-form/run-form.component.html
+++ b/jscout/src/app/run-form/run-form.component.html
@@ -43,4 +43,4 @@
   </form>
 </div>
 
-{{ payload }}
+<!--{{ payload }}-->

--- a/jscout/src/app/run-form/run-form.component.ts
+++ b/jscout/src/app/run-form/run-form.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnInit }  from '@angular/core';
-import { FormGroup }                 from '@angular/forms';
+import { FormGroup, FormControl }                 from '@angular/forms';
 
 import { QuestionBase }              from '../questions/question-base';
 import { QuestionControlService }    from '../question-control.service';
@@ -9,13 +9,18 @@ import { QuestionControlService }    from '../question-control.service';
   templateUrl: './run-form.component.html',
   providers: [ QuestionControlService ]
 })
+
 export class RunFormComponent implements OnInit {
+
+  @Input() team: number;
+  @Input() run: number;
 
   @Input() setupQuestions: QuestionBase<any>[] = [];
   @Input() autoQuestions: QuestionBase<any>[] = [];
   @Input() teleopQuestions: QuestionBase<any>[] = [];
   @Input() endgameQuestions: QuestionBase<any>[] = [];
   form: FormGroup;
+  numbers: FormGroup;
   setupForm: FormGroup;
   autoForm: FormGroup;
   teleopForm: FormGroup;
@@ -28,6 +33,7 @@ export class RunFormComponent implements OnInit {
 
   ngOnInit() {
     this.form = new FormGroup({});
+    this.numbers = new FormGroup({ TeamNumber: new FormControl(this.team), MatchNumber: new FormControl(this.run) });
     this.setupForm = this.qcs.toFormGroup(this.setupQuestions);
     this.autoForm = this.qcs.toFormGroup(this.autoQuestions);
     this.teleopForm = this.qcs.toFormGroup(this.teleopQuestions);
@@ -46,7 +52,7 @@ get payload() {
   // create timestamp object
   var timestamp = {Timestamp: String(year + '-' + month + '-' + day + ' ' + hour + ':' + minute + ':' + second)}
   // create JSON payload from all form objects
-  return JSON.stringify(Object.assign({}, this.setupForm.value, this.autoForm.value, this.teleopForm.value, this.endgameForm.value, timestamp));
+  return JSON.stringify(Object.assign({}, this.numbers.value, this.setupForm.value, this.autoForm.value, this.teleopForm.value, this.endgameForm.value, timestamp));
 }
 
 // submit function

--- a/jscout/src/styles.css
+++ b/jscout/src/styles.css
@@ -80,6 +80,23 @@ button[type="submit"] {
 	margin: 10px;
 }
 
+.narrow-column {
+	padding: 5px;
+	margin: auto;
+	max-width: 900px;
+	display: -webkit-box;
+	display: -moz-box;
+	display: -ms-flexbox;
+	display: -webkit-flex;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.narrow-column * {
+	margin: 10px;
+}
+
 .form-inline * {
 	margin: 10px;
 }


### PR DESCRIPTION
<!--- (this is a comment) Thanks for your contribution! We look forward to quickly merging your PR, so please follow this template to speed processing. Thanks again! -->

**Brief description of your changes:**
Modified the splash screen to contain Team # and Run # input fields which are then passed to the main form.

The browser back button now also returns to the splash screen.

**What issue(s) does this PR close/update/change/reference?**
<!-- type the # sign and a helpful suggestions menu will appear -->
None, but it is a step towards a functioning lockout and user identification system

<!-- if not adequately described above, in issues, and in commit messages, add additional details of your improvements here -->

**Have (how have) you validated the functionality of these changes? Is there a server where we can view these changes?**
<!-- maintainers: before merging to prod, full regression testing of all functionality should be done on the test server -->
Changes have only been made to visual aspects of the frontend so testing has only been done on my personal machine, but I have checked to verify that the payload output is still working properly.