### PR TITLE
User Tracking via cookie

### DIFF
--- a/jscout/Dockerfile
+++ b/jscout/Dockerfile
@@ -2,6 +2,7 @@ FROM alpine AS builder
 WORKDIR /strangescout
 RUN apk add --update nodejs nodejs-npm
 COPY ./ ./
+RUN sed -i s/localhost/$JSCOUT_DOMAIN/ src/environments/environment.prod.ts
 RUN npm install -g @angular/cli
 RUN npm update --save
 RUN ng build --prod

--- a/jscout/package-lock.json
+++ b/jscout/package-lock.json
@@ -6257,6 +6257,11 @@
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
     },
+    "ngx-cookie-service": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/ngx-cookie-service/-/ngx-cookie-service-1.0.10.tgz",
+      "integrity": "sha512-TAXpQsIONAupTqkUDcH44hFQsLTvsXpxM80eKgxvy3vhBFfT1uIdR7BRhM7VpUW5J7BN9qCbGNgLN5lsnVu7pw=="
+    },
     "no-case": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",

--- a/jscout/package.json
+++ b/jscout/package.json
@@ -25,6 +25,7 @@
     "@angular/router": "^6.1.0",
     "@angular/service-worker": "^6.1.0",
     "core-js": "^2.5.4",
+    "ngx-cookie-service": "^1.0.10",
     "rxjs": "^6.0.0",
     "zone.js": "~0.8.26"
   },

--- a/jscout/src/app/app.component.html
+++ b/jscout/src/app/app.component.html
@@ -46,6 +46,7 @@
   </div>
   <div class="center-content">
     <button class="btn btn-default btn-primary item" [disabled]="!runInput.valid || !teamInput.valid" (click)="visiblePage='run'">Scout!</button>
+    <button (click)="resetScouter()">Reset Scouter ID</button>
   </div>
 </div>
 

--- a/jscout/src/app/app.component.html
+++ b/jscout/src/app/app.component.html
@@ -27,6 +27,7 @@
 
 <div *ngIf="visiblePage == 'splash'" class="container-fluid form-container">
   <!-- Home page content goes here -->
+  <div class="center-content"><h3>Welcome back {{ scouter }}!</h3></div>
   <div class="narrow-column">
     <span>
       <legend>Team:</legend>
@@ -50,5 +51,5 @@
 
 <!-- Run scouting form -->
 <div *ngIf="visiblePage == 'run'" class="container-fluid form-container">
-  <app-run-form [team]="team" [run]="run" [setupQuestions]="setupQuestions" [autoQuestions]="autoQuestions" [teleopQuestions]="teleopQuestions" [endgameQuestions]="endgameQuestions"></app-run-form>
+  <app-run-form [scouter]="scouter" [team]="team" [run]="run" [setupQuestions]="setupQuestions" [autoQuestions]="autoQuestions" [teleopQuestions]="teleopQuestions" [endgameQuestions]="endgameQuestions"></app-run-form>
 </div>

--- a/jscout/src/app/app.component.html
+++ b/jscout/src/app/app.component.html
@@ -46,7 +46,9 @@
   </div>
   <div class="center-content">
     <button class="btn btn-default btn-primary item" [disabled]="!runInput.valid || !teamInput.valid" (click)="visiblePage='run'">Scout!</button>
-    <button (click)="resetScouter()">Reset Scouter ID</button>
+  </div>
+  <div class="center-content">
+    <button class="btn btn-warning item" (click)="resetScouter()">Reset Scouter ID</button>
   </div>
 </div>
 

--- a/jscout/src/app/app.component.ts
+++ b/jscout/src/app/app.component.ts
@@ -56,7 +56,9 @@ export class AppComponent {
       do {
         this.scouter = window.prompt("Enter scouter name:");
       } while(this.scouter == null || this.scouter == "" );
-      cookieService.set('scouter', this.scouter);
+      var expiredDate = new Date();
+      expiredDate.setDate( expiredDate.getDate() + 3 );
+      cookieService.set('scouter', this.scouter, expiredDate);
     } else {
       this.scouter = cookieService.get('scouter')
     }

--- a/jscout/src/app/app.component.ts
+++ b/jscout/src/app/app.component.ts
@@ -63,8 +63,10 @@ export class AppComponent {
   }
 
   resetScouter() {
-    this.cookieService.delete('scouter');
-    location.reload();
+    if (window.confirm('Are you sure?')) {
+      this.cookieService.delete('scouter');
+      location.reload();
+    }
   }
 
 }

--- a/jscout/src/app/app.component.ts
+++ b/jscout/src/app/app.component.ts
@@ -27,7 +27,7 @@ export class AppComponent {
   team: number;
   run: number;
 
-  constructor(location: PlatformLocation, qservice: QuestionService, updates: SwUpdate, cookieService: CookieService) {
+  constructor(private location: PlatformLocation, qservice: QuestionService, private updates: SwUpdate, private cookieService: CookieService) {
 
     location.onPopState(() => {
       console.log('pressed back!');
@@ -61,4 +61,10 @@ export class AppComponent {
       this.scouter = cookieService.get('scouter')
     }
   }
+
+  resetScouter() {
+    this.cookieService.delete('scouter');
+    location.reload();
+  }
+
 }

--- a/jscout/src/app/app.component.ts
+++ b/jscout/src/app/app.component.ts
@@ -3,6 +3,7 @@ import { PlatformLocation } from '@angular/common'
 import { SwUpdate } from '@angular/service-worker';
 import { interval } from 'rxjs';
 import { QuestionService } from './question.service';
+import { CookieService } from 'ngx-cookie-service';
 
 @Component({
   selector: 'app-root',
@@ -22,10 +23,11 @@ export class AppComponent {
 
   visiblePage = 'splash';
 
+  scouter: string;
   team: number;
   run: number;
 
-  constructor(location: PlatformLocation, qservice: QuestionService, updates: SwUpdate) {
+  constructor(location: PlatformLocation, qservice: QuestionService, updates: SwUpdate, cookieService: CookieService) {
 
     location.onPopState(() => {
       console.log('pressed back!');
@@ -49,5 +51,10 @@ export class AppComponent {
       console.log('new version is', event.current);
     });
     interval(30000).subscribe(() => updates.checkForUpdate());
+
+    if(cookieService.get('scouter') == '') {
+      cookieService.set('scouter', window.prompt("Enter scouter name:"));
+    }
+    this.scouter = cookieService.get('scouter')
   }
 }

--- a/jscout/src/app/app.component.ts
+++ b/jscout/src/app/app.component.ts
@@ -4,6 +4,7 @@ import { SwUpdate } from '@angular/service-worker';
 import { interval } from 'rxjs';
 import { QuestionService } from './question.service';
 import { CookieService } from 'ngx-cookie-service';
+import { environment } from '../environments/environment';
 
 @Component({
   selector: 'app-root',
@@ -58,7 +59,7 @@ export class AppComponent {
       } while(this.scouter == null || this.scouter == "" );
       var expiredDate = new Date();
       expiredDate.setDate( expiredDate.getDate() + 3 );
-      cookieService.set('scouter', this.scouter, expiredDate);
+      cookieService.set('scouter', this.scouter, expiredDate, "/", environment.domain);
     } else {
       this.scouter = cookieService.get('scouter')
     }

--- a/jscout/src/app/app.component.ts
+++ b/jscout/src/app/app.component.ts
@@ -56,7 +56,9 @@ export class AppComponent {
       do {
         this.scouter = window.prompt("Enter scouter name:");
       } while(this.scouter == null || this.scouter == "" );
+      cookieService.set('scouter', this.scouter);
+    } else {
+      this.scouter = cookieService.get('scouter')
     }
-    this.scouter = cookieService.get('scouter')
   }
 }

--- a/jscout/src/app/app.component.ts
+++ b/jscout/src/app/app.component.ts
@@ -53,7 +53,9 @@ export class AppComponent {
     interval(30000).subscribe(() => updates.checkForUpdate());
 
     if(cookieService.get('scouter') == '') {
-      cookieService.set('scouter', window.prompt("Enter scouter name:"));
+      do {
+        this.scouter = window.prompt("Enter scouter name:");
+      } while(this.scouter == null || this.scouter == "" );
     }
     this.scouter = cookieService.get('scouter')
   }

--- a/jscout/src/app/app.module.ts
+++ b/jscout/src/app/app.module.ts
@@ -1,9 +1,18 @@
-import { BrowserModule }                from '@angular/platform-browser';
-import { FormsModule, ReactiveFormsModule }          from '@angular/forms';
-import { NgModule }                     from '@angular/core';
+// Core imports
+import { BrowserModule } from '@angular/platform-browser';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { NgModule } from '@angular/core';
+import { environment } from '../environments/environment';
 
-import { AppComponent }                 from './app.component';
-import { RunFormComponent }         from './run-form/run-form.component';
+// Service worker
+import { ServiceWorkerModule } from '@angular/service-worker';
+
+// Cookies
+import { CookieService } from 'ngx-cookie-service';
+
+// Components
+import { AppComponent } from './app.component';
+import { RunFormComponent } from './run-form/run-form.component';
 import { FormQuestionComponent } from './form-question/form-question.component';
 
 // Material elements
@@ -12,13 +21,12 @@ import {MatToolbarModule} from '@angular/material/toolbar';
 import {MatMenuModule} from '@angular/material/menu';
 import {MatButtonModule} from '@angular/material/button';
 import {MatIconModule} from '@angular/material/icon';
-import { ServiceWorkerModule } from '@angular/service-worker';
-import { environment } from '../environments/environment';
 
 
 @NgModule({
   imports: [ BrowserModule, FormsModule, ReactiveFormsModule, BrowserAnimationsModule, MatToolbarModule, MatMenuModule, MatButtonModule, MatIconModule, ServiceWorkerModule.register('ngsw-worker.js', { enabled: environment.production })],
   declarations: [ AppComponent, RunFormComponent, FormQuestionComponent ],
+  providers: [ CookieService ],
   bootstrap: [ AppComponent ]
 })
 export class AppModule {

--- a/jscout/src/app/run-form/run-form.component.html
+++ b/jscout/src/app/run-form/run-form.component.html
@@ -5,10 +5,10 @@
       <legend>Setup</legend>
 
       <div>
-        <b>Team:</b> {{ numbers.get('TeamNumber').value }}
+        <b>Team:</b> {{ initialization.get('TeamNumber').value }}
       </div>
       <div>
-        <b>Run:</b> {{ numbers.get('MatchNumber').value }}
+        <b>Run:</b> {{ initialization.get('MatchNumber').value }}
       </div>
 
       <div *ngFor="let question of setupQuestions" class="form-group">

--- a/jscout/src/app/run-form/run-form.component.ts
+++ b/jscout/src/app/run-form/run-form.component.ts
@@ -1,8 +1,8 @@
-import { Component, Input, OnInit }  from '@angular/core';
-import { FormGroup, FormControl }                 from '@angular/forms';
+import { Component, Input, OnInit } from '@angular/core';
+import { FormGroup, FormControl } from '@angular/forms';
 
-import { QuestionBase }              from '../questions/question-base';
-import { QuestionControlService }    from '../question-control.service';
+import { QuestionBase } from '../questions/question-base';
+import { QuestionControlService } from '../question-control.service';
 
 @Component({
   selector: 'app-run-form',
@@ -12,6 +12,7 @@ import { QuestionControlService }    from '../question-control.service';
 
 export class RunFormComponent implements OnInit {
 
+  @Input() scouter: string;
   @Input() team: number;
   @Input() run: number;
 
@@ -20,7 +21,7 @@ export class RunFormComponent implements OnInit {
   @Input() teleopQuestions: QuestionBase<any>[] = [];
   @Input() endgameQuestions: QuestionBase<any>[] = [];
   form: FormGroup;
-  numbers: FormGroup;
+  initialization: FormGroup;
   setupForm: FormGroup;
   autoForm: FormGroup;
   teleopForm: FormGroup;
@@ -33,7 +34,7 @@ export class RunFormComponent implements OnInit {
 
   ngOnInit() {
     this.form = new FormGroup({});
-    this.numbers = new FormGroup({ TeamNumber: new FormControl(this.team), MatchNumber: new FormControl(this.run) });
+    this.initialization = new FormGroup({Scouter: new FormControl(this.scouter), TeamNumber: new FormControl(this.team), MatchNumber: new FormControl(this.run) });
     this.setupForm = this.qcs.toFormGroup(this.setupQuestions);
     this.autoForm = this.qcs.toFormGroup(this.autoQuestions);
     this.teleopForm = this.qcs.toFormGroup(this.teleopQuestions);
@@ -52,7 +53,7 @@ get payload() {
   // create timestamp object
   var timestamp = {Timestamp: String(year + '-' + month + '-' + day + ' ' + hour + ':' + minute + ':' + second)}
   // create JSON payload from all form objects
-  return JSON.stringify(Object.assign({}, this.numbers.value, this.setupForm.value, this.autoForm.value, this.teleopForm.value, this.endgameForm.value, timestamp));
+  return JSON.stringify(Object.assign({}, this.initialization.value, this.setupForm.value, this.autoForm.value, this.teleopForm.value, this.endgameForm.value, timestamp));
 }
 
 // submit function

--- a/jscout/src/environments/environment.prod.ts
+++ b/jscout/src/environments/environment.prod.ts
@@ -1,3 +1,4 @@
 export const environment = {
-  production: true
+  production: true,
+  domain: 'localhost'
 };

--- a/jscout/src/environments/environment.ts
+++ b/jscout/src/environments/environment.ts
@@ -3,7 +3,8 @@
 // The list of file replacements can be found in `angular.json`.
 
 export const environment = {
-  production: false
+  production: false,
+  domain: 'localhost'
 };
 
 /*

--- a/jscout/src/styles.css
+++ b/jscout/src/styles.css
@@ -63,6 +63,7 @@ button[type="submit"] {
 }
 .center-content * {
 	margin: 10px;
+	text-align: center;
 }
 
 .narrow-column {


### PR DESCRIPTION
<!--- (this is a comment) Thanks for your contribution! We look forward to quickly merging your PR, so please follow this template to speed processing. Thanks again! -->

**Brief description of your changes:**
Implement a cookie to store the name of the scouter (basic user tracking)

Currently to make cookies save and be persistent on iOS devices a path and domain must be specified. The only way to reliably get the domain into Angular on build is through Angular's environment files. By default the domain variable in the environment files is set to `localhost` which will work fine when using Angular's built in live test server, but needs to be changed when deployed on an actual server. This is done via a sed command in the Dockerfile, and the `JSCOUT_DOMAIN` environment variable. This system works fine when using Docker to build as intended, but if you want to build JScout manually standalone you must edit the environment files (located in `jscout/src/environments/`) to manually specify your domain.

We will be looking in to a better way of passing this variable to Angular, in the meantime this works well and there is no real need to change it.