### PR TITLE
Policy Cleanup

### DIFF
--- a/jscout/Caddyfile
+++ b/jscout/Caddyfile
@@ -34,6 +34,4 @@
 	# for Docker logs
 	log stdout
 	errors stdout
-
-	header / Cache-Control "public"
 }

--- a/jscout/Caddyfile-traefik
+++ b/jscout/Caddyfile-traefik
@@ -27,6 +27,4 @@
 	# for Docker logs
 	log stdout
 	errors stdout
-
-	header / Cache-Control "public"
 }

--- a/jscout/Dockerfile-traefik
+++ b/jscout/Dockerfile-traefik
@@ -10,7 +10,7 @@ RUN npm update --save
 RUN ng build --prod
 
 FROM joshix/caddy:latest
-COPY Caddyfile_traefik /var/www/html/Caddyfile
+COPY Caddyfile-traefik /var/www/html/Caddyfile
 COPY --from=builder /strangescout/dist/jscout /srv
 EXPOSE 80 443
 VOLUME /.caddy/

--- a/jscout/ngsw-config.json
+++ b/jscout/ngsw-config.json
@@ -1,5 +1,16 @@
 {
   "index": "/index.html",
+  "dataGroups": [
+    {
+      "name": "api",
+      "urls": ["/api"],
+      "cacheConfig": {
+        "maxSize": 0,
+        "maxAge": "0u",
+        "strategy": "freshness"
+      }
+    }
+  ],
   "assetGroups": [
     {
       "name": "app",

--- a/jscout/src/app/app-routing.module.ts
+++ b/jscout/src/app/app-routing.module.ts
@@ -12,7 +12,7 @@ const routes: Routes = [
 ];
 
 @NgModule({
-	imports: [RouterModule.forRoot(routes)],
+	imports: [RouterModule.forRoot(routes, { useHash: true })],
 	exports: [RouterModule]
 })
 export class AppRoutingModule { }


### PR DESCRIPTION
**Brief description of your changes:**
- Remove old unnecessary `Cache-Control` header
- Set cache policies in the service worker for API requests

**What issue(s) does this PR close/update/change/reference?**
- This allows access to the API in a web browser again, which was previously being intercepted by angular routing thanks to the service worker