### PR TITLE
Make stronger logout warning

### DIFF
--- a/jscout/src/app/confirm-dialog/confirm-dialog.component.html
+++ b/jscout/src/app/confirm-dialog/confirm-dialog.component.html
@@ -1,5 +1,6 @@
+<h2 mat-dialog-title>Logout?</h2>
 <div mat-dialog-content>
-		Are you sure?
+		Logging out will prevent any pending data from being uploaded to the server. You will not be able to use StrangeScout until you sign in again, which will require a network connection.
 </div>
 <div mat-dialog-actions>
 		<button mat-button cdkFocusInitial type="button" (click)="dialogRef.close(false)">Cancel</button>


### PR DESCRIPTION
<!--- (this is a comment) Thanks for your contribution! We look forward to quickly merging your PR, so please follow this template to speed processing. Thanks again! -->

**Brief description of your changes:**
Make the logout warning stronger, emphasizing that the application will be unusable until the user reconnects to a network and logs in again. As I understand it right now the database isn't cleared, so the data isn't going to deleted, but we have automatic sync on the development roadmap so we definitely want to be clear to users that this will disrupt the uploading of their data. Unless you want to just go ahead and say it will be deleted?