### PR TITLE
Guilford Event Suggestions / Defense Tracking

### DIFF
--- a/frontend/web/src/app/analysis/analysis.component.html
+++ b/frontend/web/src/app/analysis/analysis.component.html
@@ -46,6 +46,10 @@
 						<!-- Average drop count from entry -->
 						Average Drops: {{ entry.averages.drops }}
 					</mat-list-item>
+					<mat-list-item role="listitem">
+						<!-- Average defense time from entry -->
+						Average Defense Time: {{ entry.averages.defensetime }} seconds
+					</mat-list-item>
 				</mat-list>
 				<mat-accordion multi="true">
 					<mat-expansion-panel>

--- a/frontend/web/src/app/analysis/analysis.component.html
+++ b/frontend/web/src/app/analysis/analysis.component.html
@@ -131,5 +131,9 @@
 		<h3 class="mat-card-title">Average Cargo</h3>
 		<div id="cargochart"></div>
 	</div>
+	<div class="chart-container">
+		<h3 class="mat-card-title">Average Defense Time</h3>
+		<div id="defensechart"></div>
+	</div>
 </mat-tab>
 </mat-tab-group>

--- a/frontend/web/src/app/analysis/analysis.component.ts
+++ b/frontend/web/src/app/analysis/analysis.component.ts
@@ -24,6 +24,7 @@ export class AnalysisComponent implements AfterViewInit {
 		{name: 'Match Count', value: 'matchCount'},
 		{name: 'Cycle Count', value: 'averages.cycles'},
 		{name: 'Drop Count', value: 'averages.drops'},
+		{name: 'Defense Time', value: 'averages.defensetime'},
 		{name: 'Hatch Cycle Count', value: 'averages.hatch.cycles'},
 		{name: 'Hatch Drop Count', value: 'averages.hatch.drops'},
 		{name: 'Cargo Cycle Count', value: 'averages.cargo.cycles'},
@@ -74,6 +75,9 @@ export class AnalysisComponent implements AfterViewInit {
 				this.sp.averageDrops(entry.team, entry.rawdata).then(result => {
 					this.data[index].averages.drops = Math.ceil(result*100)/100;
 				});
+				this.sp.averageDefenseTime(entry.team, entry.rawdata).then(result => {
+					this.data[index].averages.defensetime = Math.ceil(result*100)/100;
+				})
 
 // HATCH -------------------------------
 

--- a/frontend/web/src/app/analysis/analysis.component.ts
+++ b/frontend/web/src/app/analysis/analysis.component.ts
@@ -36,6 +36,7 @@ export class AnalysisComponent implements AfterViewInit {
 	dropchart: any;
 	hatchchart: any;
 	cargochart: any;
+	defensechart: any;
 // -------------------------------------
 
 	constructor(public sp: StrangeparseService) {
@@ -261,6 +262,21 @@ export class AnalysisComponent implements AfterViewInit {
 				}}
 			}
 		});
+		this.defensechart = c3.generate({
+			bindto: '#defensechart',
+			data: {
+				type: 'bar',
+				columns: [],
+				order: null
+			},
+			bar: {width: {
+					ratio: 0.5
+			}},
+			axis: {x: {tick: {
+					format: (x) => {return ''}
+				}}
+			}
+		});
 	}
 
 	reloadGraphs() {
@@ -279,6 +295,10 @@ export class AnalysisComponent implements AfterViewInit {
 		this.cargochart.load({
 			unload: true,
 			columns: this.cargocolumns
+		});
+		this.defensechart.load({
+			unload: true,
+			columns: this.defensecolumns
 		});
 	}
 
@@ -313,6 +333,14 @@ export class AnalysisComponent implements AfterViewInit {
 		columns = [];	
 		this.data.forEach((element) => {
 			columns.push([element.team.toString(), element.averages.cargo.cycles])
+		});
+		return columns;
+	}
+	get defensecolumns() {
+		let columns: any[];
+		columns = [];	
+		this.data.forEach((element) => {
+			columns.push([element.team.toString(), element.averages.defensetime])
 		});
 		return columns;
 	}

--- a/frontend/web/src/app/dialogs/begin-match-dialog/begin-match-dialog.component.html
+++ b/frontend/web/src/app/dialogs/begin-match-dialog/begin-match-dialog.component.html
@@ -2,5 +2,6 @@
 	Click when the match starts!
 </div>
 <div mat-dialog-actions>
-	<button mat-button mat-dialog-close cdkFocusInitial>Begin Match</button>
+	<button mat-button (click)="dialogRef.close(false)">Close</button>
+	<button mat-button cdkFocusInitial (click)="dialogRef.close(true)">Begin Match</button>
 </div>

--- a/frontend/web/src/app/dialogs/begin-match-dialog/begin-match-dialog.component.ts
+++ b/frontend/web/src/app/dialogs/begin-match-dialog/begin-match-dialog.component.ts
@@ -7,5 +7,5 @@ import { MatDialogRef } from '@angular/material';
 	styleUrls: ['./begin-match-dialog.component.css']
 })
 export class BeginMatchDialogComponent {
-	public dialogRef: MatDialogRef<BeginMatchDialogComponent>;
+	constructor(public dialogRef: MatDialogRef<BeginMatchDialogComponent>) {}
 }

--- a/frontend/web/src/app/run-form-data.service.ts
+++ b/frontend/web/src/app/run-form-data.service.ts
@@ -62,7 +62,8 @@ export class RunFormDataService {
 			SubEvents: [
 				{Name: 'Level 1', Value: 'L1Climb'},
 				{Name: 'Level 2', Value: 'L2Climb'},
-				{Name: 'Level 3', Value: 'L3Climb'}
+				{Name: 'Level 3', Value: 'L3Climb'},
+				{Name: 'Incomplete', Value: 'DNFClimb'}
 			]
 		}
 	];

--- a/frontend/web/src/app/run-form-data.service.ts
+++ b/frontend/web/src/app/run-form-data.service.ts
@@ -56,7 +56,7 @@ export class RunFormDataService {
 		},
 		{
 			Name: 'Start Habitat Climb',
-			RevealTime: 120,
+			RevealTime: 90,
 			IgnoreHolding: true,
 			Event: 'startClimb',
 			SubEvents: [

--- a/frontend/web/src/app/run-form/run-form.component.css
+++ b/frontend/web/src/app/run-form/run-form.component.css
@@ -46,7 +46,3 @@ button.element-button {
 .setup-field {
 	width: 100%;
 }
-
-.countdown {
-	padding-bottom: 10px;
-}

--- a/frontend/web/src/app/run-form/run-form.component.html
+++ b/frontend/web/src/app/run-form/run-form.component.html
@@ -48,7 +48,8 @@
 <mat-card *ngIf="showForm" style="text-align: center;">
 	<ng-container [counter]="counter" [interval]="interval" (value)="time = $event">
 		<h3 class="countdown">Remaining Time: {{ displayTime }}</h3>
-		Last Event: {{ lastEvent }}
+		<p>Team: {{ team }}</p>
+		<p>Last Event: {{ lastEvent }}</p>
 	</ng-container>
 </mat-card>
 

--- a/frontend/web/src/app/run-form/run-form.component.html
+++ b/frontend/web/src/app/run-form/run-form.component.html
@@ -55,7 +55,13 @@
 
 <mat-card *ngIf="showForm" class="button-card">
 	<div *ngFor="let element of gameElements">
-		<button mat-raised-button *ngIf="showForm" class="element-button" type="button" color="primary" [disabled]="(counter - time) < (element.RevealTime + 1) || time < 1 || (holding !== element.Name && holding !== '' && !element.IgnoreHolding)" (click)="getElement(element)">{{element.Name}}</button>
+		<button mat-raised-button *ngIf="showForm" class="element-button" type="button" color="primary" [disabled]="(counter - time) < (element.RevealTime + 1) || time < 1 || (holding !== element.Name && holding !== '' && !element.IgnoreHolding) || defending" (click)="getElement(element)">{{element.Name}}</button>
+	</div>
+	<div>
+		<button mat-raised-button *ngIf="showForm" class="element-button" type="button" color="primary" [disabled]="time < 1" (click)="toggleDefense()">
+		<ng-container *ngIf="!defending">Start Defending</ng-container>
+		<ng-container *ngIf="defending">Stop Defending</ng-container>
+		</button>
 	</div>
 </mat-card>
 

--- a/frontend/web/src/app/run-form/run-form.component.ts
+++ b/frontend/web/src/app/run-form/run-form.component.ts
@@ -71,42 +71,44 @@ export class RunFormComponent implements OnInit {
 	 */
 	startMatch() {
 		// popup before match start
-		const dialogRef = this.dialog.open(BeginMatchDialogComponent);
+		const dialogRef = this.dialog.open(BeginMatchDialogComponent, {disableClose: true});
 		// after closing popup
 		dialogRef.afterClosed().subscribe(result => {
-			// show form body
-			this.showForm = true;
+			if (result) {
+				// show form body
+				this.showForm = true;
 
-			// if the starting load is not "none"
-			if (this.load !== 'none') {
-				// local var of load
-				const load = this.load;
+				// if the starting load is not "none"
+				if (this.load !== 'none') {
+					// local var of load
+					const load = this.load;
 
-				// loadout journal entry
-				let entry = new EventJournalEntry;
-				entry.Time = 0;
-				entry.Event = this.load;
-				this.journal.push(entry);
-				
-				// find the gameElement with a matching top level event to the load value
-				const element = this.gameElements.find(item => {
-					return item.Event === load;
-				});
-				this.holding = element.Name;
-				// opens a popup with sub events
-				const dialogRef = this.dialog.open(ElementEventDialogComponent, {width: '250px', disableClose: true, autoFocus: false, data: element});
-				// after the popup is closed
-				dialogRef.afterClosed().subscribe(result => {
-					if (result === 'cancel') {
-						// remove last event if canceled
-						this.journal.pop();
-						this.holding = '';
-					} else if (result !== 'hold') {
-						// new event
-						this.newJournalEntry(result);
-						this.holding = '';
-					}
-				});
+					// loadout journal entry
+					let entry = new EventJournalEntry;
+					entry.Time = 0;
+					entry.Event = this.load;
+					this.journal.push(entry);
+
+					// find the gameElement with a matching top level event to the load value
+					const element = this.gameElements.find(item => {
+						return item.Event === load;
+					});
+					this.holding = element.Name;
+					// opens a popup with sub events
+					const dialogRef = this.dialog.open(ElementEventDialogComponent, {width: '250px', disableClose: true, autoFocus: false, data: element});
+					// after the popup is closed
+					dialogRef.afterClosed().subscribe(result => {
+						if (result === 'cancel') {
+							// remove last event if canceled
+							this.journal.pop();
+							this.holding = '';
+						} else if (result !== 'hold') {
+							// new event
+							this.newJournalEntry(result);
+							this.holding = '';
+						}
+					});
+				}
 			}
 		});
 	}

--- a/frontend/web/src/app/run-form/run-form.component.ts
+++ b/frontend/web/src/app/run-form/run-form.component.ts
@@ -50,6 +50,9 @@ export class RunFormComponent implements OnInit {
 	// used to disable buttons if a robot is holding an element
 	holding = '';
 
+	// currently defending?
+	defending = false;
+
 	// starting positions
 	startingPositions: OptionEventChoice[] = RunFormDataService.startingPositions;
 	// starting configs
@@ -220,6 +223,10 @@ export class RunFormComponent implements OnInit {
 	 * Opens end match dialog containing notes - on close submits the payload
 	 */
 	endMatch() {
+		// end defense if currently defending
+		if (this.defending) {
+			this.toggleDefense();
+		}
 		// popup before match start
 		const dialogRef = this.dialog.open(EndMatchDialogComponent, {disableClose: true});
 		// after closing popup
@@ -294,6 +301,16 @@ export class RunFormComponent implements OnInit {
 					this.holding = '';
 				}
 			});
+		}
+	}
+
+	toggleDefense() {
+		if (this.defending) {
+			this.newJournalEntry('stopDefense');
+			this.defending = false;
+		} else {
+			this.newJournalEntry('startDefense');
+			this.defending = true;
 		}
 	}
 

--- a/frontend/web/src/app/services/strangeparse.service.ts
+++ b/frontend/web/src/app/services/strangeparse.service.ts
@@ -164,7 +164,8 @@ export class StrangeparseService {
 			});
 			
 			let droplessjournal = this.removeDrops(concatjournal);
-			let average = (droplessjournal.length / 2) / teamdata.length;
+			let climblessjournal = this.removeClimb(droplessjournal);
+			let average = (climblessjournal.length / 2) / teamdata.length;
 
 			resolve(average);
 		});
@@ -387,6 +388,17 @@ export class StrangeparseService {
 		});
 
 		return newjournal;
+	}
+
+	/**
+	 * Removes climbs from a journal
+	 * @param src source journal
+	 */
+	removeClimb(src: any[]): any[] {
+		while (src[src.length - 1].Event.substr(src[src.length - 1].Event.length - 5) === 'Climb') {
+			src.pop();
+		}
+		return src;
 	}
 
 // EXTRA -------------------------------

--- a/frontend/web/src/app/services/strangeparse.service.ts
+++ b/frontend/web/src/app/services/strangeparse.service.ts
@@ -310,6 +310,7 @@ export class StrangeparseService {
 			let teamdata: any[];
 
 			let totaltime = 0;
+			let average = 0;
 			
 			if (rawdata) {
 				teamdata = rawdata;
@@ -333,7 +334,9 @@ export class StrangeparseService {
 				}
 			});
 
-			let average = totaltime / (defensejournal.length / 2);
+			if (defensejournal.length !== 0) {
+				average = totaltime / (defensejournal.length / 2);
+			}
 
 			resolve(average);
 		})

--- a/frontend/web/src/app/services/strangeparse.service.ts
+++ b/frontend/web/src/app/services/strangeparse.service.ts
@@ -165,7 +165,8 @@ export class StrangeparseService {
 			
 			let droplessjournal = this.removeDrops(concatjournal);
 			let climblessjournal = this.removeClimb(droplessjournal);
-			let average = (climblessjournal.length / 2) / teamdata.length;
+			let defenselessjournal = this.removeDefense(climblessjournal);
+			let average = (defenselessjournal.length / 2) / teamdata.length;
 
 			resolve(average);
 		});
@@ -347,6 +348,26 @@ export class StrangeparseService {
 			word2 = words[words.length - 1];
 
 			if ((word2.toLowerCase() === element.toLowerCase()) && (word1.toLowerCase() === destination.toLowerCase())) {
+				newjournal.push(event);
+			}
+		});
+
+		return newjournal;
+	}
+
+	/**
+	 * removes defense from a journal
+	 * @param journal journal to remove defense from
+	 */
+	removeDefense(journal: any[]): any[] {
+		let newjournal = [];
+
+		journal.forEach(event => {
+			let eventname = event.Event.replace(/([a-z\xE0-\xFF])([A-Z\xC0\xDF])/g, '$1 $2');
+			let word = eventname.replace(/^./, str => {
+				return str.toLowerCase();
+			}).split(' ')[1];
+			if (word !== 'Defense') {
 				newjournal.push(event);
 			}
 		});

--- a/frontend/web/src/app/services/strangeparse.service.ts
+++ b/frontend/web/src/app/services/strangeparse.service.ts
@@ -335,7 +335,7 @@ export class StrangeparseService {
 			});
 
 			if (defensejournal.length !== 0) {
-				average = totaltime / (defensejournal.length / 2);
+				average = totaltime / teamdata.length;
 			}
 
 			resolve(average);


### PR DESCRIPTION
Bug fixes and updates in suggestions given after our first event

### Begin Match Dialog
- can now be closed to make modifications to initial setup before match starts
- fixed bug where clicking outside the dialog would start the match

### Status Card
- show currently scouting team number

### Hab Climb
- button now enables earlier at T-60 seconds
- add new option for failed climbs

## Defense Tracking

### Scouting Form
- toggle button for when a robot begins defense
    - also disables all other event buttons until defense is toggled off again

### Analysis Page
- shows average seconds spent on defense
- new graph for average defense seconds